### PR TITLE
Incorporate technical documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,15 @@ Using the product roadmap, OCS staff and 18F will identify discrete modules that
 
 ### Put in place a DevOps infrastructure
 
-Before OCS can adopt a modular procurement strategy and adopt agile practices, it needs to develop a capacity to accept work delivered in an iterative fashion. Adopting DevOps practices and constructing a delivery pipeline are essential to the successful adoption of agile practices. 
+Before OCS can adopt a modular procurement strategy and adopt agile practices, it needs to develop a capacity to accept work delivered in an iterative fashion. Adopting DevOps practices and constructing a delivery pipeline are essential to the successful adoption of agile practices.
 
 ## Risks 
 
 * Ensuring a focus on end users. There may be a strong incentive to develop a CCWIS system provided by the new regulations promulgated by DHSS/ACF. Ensuring the effort to modernize the existing system is focused on delivering value to end users will require effort on the part of OCS and 18F. 
 * Compliance with CCWIS. Future funding from ACF is linked to compliance with CCWIS requirements, and ORCA modernization / enhancement efforts will need to help OCS achieve this goal.
 * Feasibility of encasement strategy. It is currently unknown how feasible 18F's standard "encasement" approach to legacy modernization is for the existing ORCA system.
+* ORCA contains considerable technical debt, [as documented](TechnicalDebt.md).
+* See [Technical Risks](TechnicalRisks.md) for more.
 
 ## Ongoing Strategic Issues
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ This initial focus will help the product team to:
 
 ## Strategies
 
+### Encase ORCA
+
+We will identify a portion of ORCA’s functionality that can be modernized, balancing the need for adding functionality that’s of high value on mobile devices against the feasibility of opening access to that ORCA functionality within the existing Java structure. Then the existing functionality will be rewritten in a new, modernized module, using the software environment of OCS’s choosing (e.g., C# on .NET), using a responsive design (perhaps even as a progressive web app), to provide robust support for all possible clients. Finally, the old, now-redundant functionality will be eliminated.
+
 ### Adopt agile practices
 
 Working in tightly-scoped sprints to incrementally enhance the existing child welfare system will be a key to the success of a modular procurement strategy. Adopting agile practices early, even before a vendor is engaged and code is shipped, will ensure that OCS has the capacity to successfully engage with vendors. 

--- a/TechnicalDebt.md
+++ b/TechnicalDebt.md
@@ -1,0 +1,28 @@
+# Technical Debt
+
+A running list of sources of potential technical debt within ORCA and its environment.
+
+## Source Repository / Build Process
+
+### Outdated RCS
+The code is stored in [Rational ClearCase](https://en.wikipedia.org/wiki/Rational_ClearCase), a revision control system from the early 1990s. It doesn't integrate with any modern DevOps tools, which functionally blocks any modernization of the deployment process.
+
+### Homebrewed Deploy Process
+The deploy process is run on a custom system. It works just fine, but, like the use of ClearCase, this is an obstacle to integrating with modern DevOps tools.
+
+### Obviated COBOL
+The repository has a fair amount of COBOL in it. This is said to have been replaced with Java-based functionality in ~2013, but it remains in the repo.
+
+### Obviated Batch Scripts
+The repository has a fair number of batch scripts throughout, for the testing and deploy process. This is quite normal, but apparently these were replaced with Java-based functionality sometime in the past few years. Leaving them in the repo provides the illusion of functionality in the wrong place.
+
+## Front End
+
+### IE-Specific Code
+The front-end of ORCA was written in the mid-00s, targeting Internet Explorer, and it has the shortcomings that one would expect from that. Reliance on IE-specific functionality (e.g., `window.showModalDialog`) renders the site almost completely unusable in other browsers.
+
+### Tightly-Coupled Front and Back Ends
+There is no API layer separating the front end from the back end. This makes it quite difficult to modularize the site.
+
+### Intermingled Design and Functionality
+The front-end was created in an era when it wasn’t standard to use semantic HTML, restricting design to CSS. Instead, layout is done in the HTML itself. Most block elements are `div`s. This makes it difficult to e.g. move to a responsive design.

--- a/TechnicalRisks.md
+++ b/TechnicalRisks.md
@@ -1,0 +1,31 @@
+# Technical Risks
+
+The following is a living document of the technical risks associated with the ORCA Modernization project. 
+
+## Encasing ORCA is an unknown
+
+ORCA has no API. The amount of effort required to modify its internal functionality to encase it and interface with it is simply unknown at this point. It is certainly _possible_—OCS has control over all of the code that comprises ORCA—but there’s not yet any way to know whether it will be viable compared to other options (e.g., greenfield development).
+
+## There is no prototype
+
+No internal work has been done to “de-risk” the proposed scope of work, such as by building a prototype of the product planned for the first procurement, so we don’t know all of the technical risks.
+
+## Logic may not be centralized
+
+It's not clear how much logic is present in the database (e.g. stored procedures) and how much is in the Java. This may complicated encasement.
+
+## Lack of mobile device standardization
+
+There are no standard-issued mobile devices for OCS staff (e.g. iPhones), which makes it difficult to ensure that all users of the system have a quality experience. Relatedly, DHSS lacks mobile device management infrastructure to enforce minimum security standards for the mobile devices that are in use.
+
+## Inconsistent mobile service
+
+Spotty mobile coverage in rural Alaska makes it a challenge to provide a mobile experience that works reliably and consistently.
+
+## DHSS is new at DevOps
+
+It’s only over the past year that DHSS has adopted DevOps within its technical culture, and only started using it with a vendor in January. While that adoption has been aggressive and capable, it is still limited in duration and scope.
+
+## DHSS IT is stretched thin
+
+The agency’s IT positions are not fully staffed. Insofar as it is necessary for DHSS to provide technical support for this work, that presents a risk to the work being done in a timely manner.

--- a/TechnicalRisks.md
+++ b/TechnicalRisks.md
@@ -2,30 +2,14 @@
 
 The following is a living document of the technical risks associated with the ORCA Modernization project. 
 
-## Encasing ORCA is an unknown
+| Description | Criticality (1–5)<sup>*</sup> | Status |
+|---|:---:|:---:|
+|**Encasing ORCA is an unknown.** ORCA has no API. The amount of effort required to modify its internal functionality to encase it and interface with it is unknown. OCS has control over all of the code that comprises ORCA, but there’s not yet any way to know whether it will be viable compared to other options (e.g., greenfield development). | | In progress |
+**There is no prototype.** No internal work has been done to “de-risk” the proposed scope of work, such as by building a prototype of the product planned for the first procurement, so we don’t know all of the technical risks. | | In progress |
+**Logic may not be centralized.** It's not clear how much logic is present in the database (e.g. stored procedures) and how much is in the Java. This may complicated encasement. | | Not started |
+**Lack of mobile device standardization.** There are no standard-issued mobile devices for OCS staff (e.g. iPhones), which makes it difficult to ensure that all users of the system have a quality experience. Relatedly, DHSS lacks mobile device management infrastructure to enforce minimum security standards for the mobile devices that are in use. | | Not started |
+**Inconsistent mobile service.** Spotty mobile coverage in rural Alaska makes it a challenge to provide a mobile experience that works reliably and consistently. | | In progress |
+**DHSS is new at DevOps.** It’s only over the past year that DHSS has adopted DevOps within its technical culture, and only started using it with a vendor in January. While that adoption has been aggressive and capable, it is still limited in duration and scope. | | In progress |
+**DHSS IT is stretched thin.** The agency’s IT positions are not fully staffed. Insofar as it is necessary for DHSS to provide technical support for this work, that presents a risk to the work being done in a timely manner. | | Not started |
 
-ORCA has no API. The amount of effort required to modify its internal functionality to encase it and interface with it is simply unknown at this point. It is certainly _possible_—OCS has control over all of the code that comprises ORCA—but there’s not yet any way to know whether it will be viable compared to other options (e.g., greenfield development).
-
-## There is no prototype
-
-No internal work has been done to “de-risk” the proposed scope of work, such as by building a prototype of the product planned for the first procurement, so we don’t know all of the technical risks.
-
-## Logic may not be centralized
-
-It's not clear how much logic is present in the database (e.g. stored procedures) and how much is in the Java. This may complicated encasement.
-
-## Lack of mobile device standardization
-
-There are no standard-issued mobile devices for OCS staff (e.g. iPhones), which makes it difficult to ensure that all users of the system have a quality experience. Relatedly, DHSS lacks mobile device management infrastructure to enforce minimum security standards for the mobile devices that are in use.
-
-## Inconsistent mobile service
-
-Spotty mobile coverage in rural Alaska makes it a challenge to provide a mobile experience that works reliably and consistently.
-
-## DHSS is new at DevOps
-
-It’s only over the past year that DHSS has adopted DevOps within its technical culture, and only started using it with a vendor in January. While that adoption has been aggressive and capable, it is still limited in duration and scope.
-
-## DHSS IT is stretched thin
-
-The agency’s IT positions are not fully staffed. Insofar as it is necessary for DHSS to provide technical support for this work, that presents a risk to the work being done in a timely manner.
+\* 1 = low criticality; 5 = high criticality

--- a/TechnicalStrategy.md
+++ b/TechnicalStrategy.md
@@ -1,0 +1,3 @@
+# Technical Strategy
+
+We will identify a portion of ORCA’s functionality that can be modernized, balancing the need for adding functionality that’s of high value on mobile devices against the feasibility of opening access to that ORCA functionality within the existing Java structure. Then the existing functionality will be rewritten in a new, modernized module, using the software environment of OCS’s choosing (e.g., C# on .NET), using a responsive design (perhaps even as a progressive web app), to provide robust support for all possible clients. Finally, the old, now-redundant functionality will be eliminated.

--- a/TechnicalStrategy.md
+++ b/TechnicalStrategy.md
@@ -1,3 +1,0 @@
-# Technical Strategy
-
-We will identify a portion of ORCA’s functionality that can be modernized, balancing the need for adding functionality that’s of high value on mobile devices against the feasibility of opening access to that ORCA functionality within the existing Java structure. Then the existing functionality will be rewritten in a new, modernized module, using the software environment of OCS’s choosing (e.g., C# on .NET), using a responsive design (perhaps even as a progressive web app), to provide robust support for all possible clients. Finally, the old, now-redundant functionality will be eliminated.


### PR DESCRIPTION
This material was developed on [the 18F ORCA repository](https://github.com/18F/alaska-child-welfare/), and is now being incorporated here. Two of the files are moved wholesale, while a third is incorporated into the README. These changes are pursuant to Trello card #72.